### PR TITLE
Assume Markdown files are encoded in utf8

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -10,6 +10,7 @@ on 'test' => sub {
   requires "IO::Handle" => "0";
   requires "IPC::Open3" => "0";
   requires "Test::More" => "1.001005";
+  requires "Test::Mojo" => "0";
 };
 
 on 'test' => sub {

--- a/lib/Yancy/Backend/Static.pm
+++ b/lib/Yancy/Backend/Static.pm
@@ -57,6 +57,7 @@ use Text::Markdown;
 use YAML ();
 use JSON::PP ();
 use Yancy::Util qw( match order_by );
+use Encode;
 
 has schema =>;
 has path =>;
@@ -237,7 +238,7 @@ sub _parse_content {
     my ( $self, $content ) = @_;
     my %item;
 
-    my @lines = split /\n/, $content;
+    my @lines = split /\n/, decode_utf8 $content;
     # YAML frontmatter
     if ( @lines && $lines[0] =~ /^---/ ) {
         shift @lines;

--- a/t/share/site/index.markdown
+++ b/t/share/site/index.markdown
@@ -1,8 +1,7 @@
----
-title: Static Test Site
+{"title": "Static Site ⚡"}
 ---
 
 # Static Test Site
 
-This is a static test site
+🐪
 

--- a/t/site.t
+++ b/t/site.t
@@ -8,7 +8,7 @@ This tests a website built with the L<Yancy::Backend::Static> module.
 L<Yancy>
 
 =cut
-
+use utf8;
 use Test::More;
 use Test::Mojo;
 use Mojo::File qw( path );
@@ -34,9 +34,9 @@ $t->get_ok( '/index.html' )
     ->content_type_like( qr{^text/html} )
     ->text_is( h1 => 'Static Test Site' )
     ->or( sub { diag shift->tx->res->body } )
-    ->text_is( p => 'This is a static test site' )
+    ->text_is( p => '🐪' )
     ->or( sub { diag shift->tx->res->body } )
-    ->text_is( title => 'Static Test Site' )
+    ->text_is( title => 'Static Site ⚡' )
     ->or( sub { diag shift->tx->res->body } )
     ;
 
@@ -44,8 +44,8 @@ $t->get_ok( '/', 'index is default' )
     ->status_is( 200 )
     ->content_type_like( qr{^text/html} )
     ->text_is( h1 => 'Static Test Site' )
-    ->text_is( p => 'This is a static test site' )
-    ->text_is( title => 'Static Test Site' )
+    ->text_is( p => '🐪' )
+    ->text_is( title => 'Static Site ⚡' )
     ;
 
 $t->get_ok( '/about/', 'request for directory with trailing slash' )


### PR DESCRIPTION
The PR lets me write Markdown files with characters like ą or ę, and have them display correctly in a Statocles-powered blog.

This is what I think happens now, from reading a file until rendering a document by a Mojolicious app using Yancy:
- Yancy calls `Mojo::File::slurp` to get the file into a byte string
-`YAML::Load`, `Text::Markdown->new->markdown`, and everything else map byte string to byte strings
- at the end, Mojolicious puts the string into a template, e.g. through something like `<%== $item->{html} =%>`

Based on https://github.com/mojolicious/mojo/wiki/Utf-8-manipulation I see Mojolicious expects a Perl internal string for templates and there's some more precedent for assuming a provided file (configurations for the json_config plugin) is in utf8.