### PR TITLE
Add explicit return to _id_to_path

### DIFF
--- a/lib/Yancy/Backend/Static.pm
+++ b/lib/Yancy/Backend/Static.pm
@@ -216,6 +216,7 @@ sub _id_to_path {
     else {
         $id .= '.markdown';
     }
+    return $id;
 }
 
 sub _path_to_id {


### PR DESCRIPTION
Fixes bug: paths ending with an extension were mangled to "1"

The other logical branches all returned `$id` (the result of .=), but the branch for paths with the extension has
```
$id =~ s{\.\w+$}{.markdown};
```
which returns that "match was successful" i.e. 1.